### PR TITLE
Update snapshot links

### DIFF
--- a/.env-cmdrc.js
+++ b/.env-cmdrc.js
@@ -4,7 +4,7 @@ module.exports = {
     PUBLIC_URL: "/quicksync",
     SKIP_PREFLIGHT_CHECK: "true",
     // API Urls
-    REACT_APP_BACKUPS_URL: "https://storage.googleapis.com/storage/v1/b/provenance-io-test-chain-backup/o/pio-testnet-1%2Fstate-sync-latest.tar.gz",
+    REACT_APP_BACKUPS_URL: "https://storage.googleapis.com/storage/v1/b/provenance-io-test-chain-backup/o/pio-testnet-1%2Fsnapshot-latest.tar.gz",
     REACT_APP_EXPLORER_URL: "https://explorer.test.provenance.io",
     REACT_APP_DOCS_URL: "https://docs.provenance.io/blockchain/running-a-node"
   },
@@ -16,7 +16,7 @@ module.exports = {
     // App settings
     REACT_APP_ENV: "production",
     // API Urls
-    REACT_APP_BACKUPS_URL: "https://storage.googleapis.com/storage/v1/b/provenance-io-chain-backup/o/pio-mainnet-1%2Fstate-sync-latest.tar.gz",
+    REACT_APP_BACKUPS_URL: "https://storage.googleapis.com/storage/v1/b/provenance-io-chain-backup/o/pio-mainnet-1%2Fsnapshot-latest.tar.gz",
     REACT_APP_EXPLORER_URL: "https://explorer.provenance.io",
     REACT_APP_DOCS_URL: "https://docs.provenance.io/blockchain/running-a-node"
   },


### PR DESCRIPTION
This should fix the 401 issues the quicksync page gets when trying to fetch the snapshot.

see also: https://github.com/provenance-io/chain-cutter/blame/main/state-syncer/argocd/templates/config-map.yaml#L73